### PR TITLE
Fix YAML syntax error on line 63

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull_request: write
+  pull-requests: write
 
 jobs:
   validate:


### PR DESCRIPTION
Removed invalid 'P:' prefix from run: statement on line 63 that was causing GitHub Actions workflow validation to fail.

## Changes
- Fixed YAML syntax error on line 63 in the Gate 1 - TFLint Validation step
- Changed `P: run: |` to `run: |`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow: tightened permissions, adjusted workflow gating/formatting, and refined apply-stage behavior (removed outputs/summary and failure notification).
  * Updated remote state backend configuration to include a locking table and region settings.
  
**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->