### PR TITLE
Add timeout to terraform import

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -214,6 +214,14 @@ jobs:
               return 0
             fi
             
+            # Check if the operation timed out (timeout command returns 124)
+            if [ "$exit_code" -eq 124 ]; then
+              echo "❌ TIMEOUT importing $description:"
+              echo "The terraform import operation exceeded the 300 second timeout"
+              echo "::error::Import operation timed out after 300 seconds"
+              return 1
+            fi
+            
             # Check for benign errors (already in state or doesn't exist)
             if echo "$output" | grep -qE "(already exists|already imported|already manages|already|Cannot import non-existent|does not exist|Resource not found)"; then
               echo "ℹ️  $description: already in state or doesn't exist"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terraform import operations now timeout after 5 minutes, preventing indefinite hangs and ensuring timely failure notification.
  * Timeouts are explicitly detected and reported as errors so failed import steps fail fast and surface a clear timeout message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->