### PR TITLE
Fix Terraform state lock conflicts with concurrency control and plan caching

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -7,13 +7,13 @@ on:
         description: 'Type "apply" to confirm infrastructure changes'
         required: true
         type: string
-              plan_run_id:
+      plan_run_id:
         description: 'Optional: Workflow run ID containing cached Terraform plan'
         required: false
         type: string
         default: ''
 
-        # Prevent concurrent Terraform runs to avoid state lock conflicts
+# Prevent concurrent Terraform runs to avoid state lock conflicts
 concurrency:
   group: terraform-apply
   cancel-in-progress: false
@@ -161,19 +161,19 @@ jobs:
             -backend-config="dynamodb_table=${TF_STATE_DYNAMODB_TABLE}"
 
       - name: Terraform Validate
-        run: terraform -chdir=te
-        
-              - name: Download Cached Terraform Plan
+        run: terraform -chdir=terraform validate
+
+      - name: Download Cached Terraform Plan
         if: inputs.plan_run_id != ''
         uses: actions/download-artifact@v4
         with:
           name: terraform-plan
           run-id: ${{ inputs.plan_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: terraform/rraform validate
+          path: terraform
 
       - name: Terraform Plan
-              if: inputs.plan_run_id == ''
+        if: inputs.plan_run_id == ''
         id: plan
         run: |
           cd terraform
@@ -185,7 +185,7 @@ jobs:
           # Show the plan
           terraform show -no-color tfplan.out
 
-                - name: Upload Terraform Plan Artifact
+      - name: Upload Terraform Plan Artifact
         if: inputs.plan_run_id == ''
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Problem
Terraform workflows were failing with **DynamoDB state lock errors** when multiple workflow runs executed simultaneously:

```
Error: Error acquiring the state lock
ConditionalCheckFailedException from DynamoDB
```

This happened because multiple terraform-apply workflows would try to acquire the same state lock at the same time, causing conflicts.

## Solution
This PR implements a **two-part solution** to prevent state lock conflicts:

### 1. Concurrency Control
Added `concurrency` settings to ensure only one terraform-apply workflow runs at a time:
```yaml
concurrency:
  group: terraform-apply
  cancel-in-progress: false
```
- **group**: All terraform-apply workflows belong to the same concurrency group
- **cancel-in-progress: false**: New runs wait in queue instead of canceling running workflows (safe for Terraform)

### 2. Plan Caching & Reuse
Added optional `plan_run_id` input parameter to allow workflows to reuse a cached Terraform plan:
- **New input**: `plan_run_id` - Optional workflow run ID containing a cached plan
- **Download step**: Downloads cached plan if `plan_run_id` is provided
- **Upload step**: Saves plan as artifact (7-day retention) after generation
- **Skip logic**: Skips plan generation if cached plan exists

### How It Works
**Without plan_run_id** (default):
1. Workflow runs Terraform Plan
2. Uploads plan as artifact
3. Proceeds to apply

**With plan_run_id** (optional):
1. Downloads cached plan from specified run ID
2. Skips Terraform Plan step (avoids state lock)
3. Uses cached plan for apply

## Benefits
- ✅ **Prevents state lock conflicts** - Only one workflow accesses state at a time
- ✅ **Enables plan reuse** - Multiple applies can share same plan
- ✅ **Improves efficiency** - Skips redundant plan generation
- ✅ **Maintains safety** - Queues workflows instead of canceling them

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves workflow efficiency)

## Testing
To test with a cached plan:
1. Run terraform-apply workflow normally (generates and uploads plan)
2. Get the workflow run ID from the URL
3. Trigger another terraform-apply with `plan_run_id: <run_id>`
4. Second run will download and use the cached plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now supports a new workflow parameter to reference and reuse cached Terraform plans, reducing processing time for repeated runs.
  * Added execution controls to prevent concurrent Terraform operations, ensuring sequential, safe deployments.
  * Reorganized workflow sequencing to handle both cached-plan reuse and on-demand plan generation scenarios more intelligently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->