### PR TITLE
Skip hanging import step in terraform-apply workflow

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -262,7 +262,8 @@ jobs:
         run: |
           cd terraform
           echo "🔄 Attempting to import any existing resources..."
-          
+
+                if: false  # TODO: Fix hanging import step
           # Helper function to sanitize sensitive information from error output
           sanitize_output() {
             local output="$1"


### PR DESCRIPTION
Added condition to skip hanging import step in workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified infrastructure automation workflow to disable resource importation in the terraform deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->