### PR TITLE
Add KMS permissions to GitHub Actions IAM role

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -104,6 +104,26 @@ resource "aws_iam_role_policy" "github_actions_policy" {
         ]
         Resource = "${aws_cloudwatch_log_group.ecs_logs.arn}:*"
       }
+      },
+      {
+        Sid    = "KMSKeyManagement"
+        Effect = "Allow"
+        Action = [
+          "kms:CreateKey",
+          "kms:DescribeKey",
+          "kms:GetKeyPolicy",
+          "kms:GetKeyRotationStatus",
+          "kms:ListResourceTags",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:PutKeyPolicy",
+          "kms:EnableKeyRotation",
+          "kms:CreateAlias",
+          "kms:DeleteAlias",
+          "kms:UpdateAlias",
+          "kms:ListAliases"
+        ]
+        Resource = "*"
     ]
   })
 }


### PR DESCRIPTION
Adds comprehensive KMS key management permissions including CreateKey, TagResource, and alias management to fix kms:TagResource permission errors in Terraform workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced security infrastructure for automated deployment workflows to support improved key management capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->