### PR TITLE
Fix syntax error in KMS permissions block

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -124,6 +124,7 @@ resource "aws_iam_role_policy" "github_actions_policy" {
           "kms:ListAliases"
         ]
         Resource = "*"
+      }
     ]
   })
 }


### PR DESCRIPTION
Add missing closing brace after Resource = "*" to properly close the KMS policy block and fix Terraform init error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IAM permissions policy structure for GitHub Actions ensuring CloudWatch Logs monitoring access and KMS encryption key management permissions are properly recognized and applied. Corrected JSON syntax ensures all permission statements function correctly together in CI/CD workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->