### PR TITLE
Add import commands for ALB and DynamoDB table

### DIFF
--- a/terraform/import-existing-resources.sh
+++ b/terraform/import-existing-resources.sh
@@ -28,6 +28,14 @@ else
   echo "Target group not found or AWS CLI not configured"
 fi
 
+# Import Application Load Balancer
+echo "Importing ALB..."
+terraform import aws_lb.main arn:aws:elasticloadbalancing:us-west-2:462498369025:loadbalancer/app/protein-classifier-alb/c580c95b9504da26 || true
+
+# Import DynamoDB Table
+echo "Importing DynamoDB table..."
+terraform import aws_dynamodb_table.terraform_locks protein-classifier-terraform-locks || true
+
 # Import KMS Keys - these require the key ID
 echo "Importing KMS keys..."
 echo "Note: KMS keys need to be imported with their key ID. You'll need to find these manually:"


### PR DESCRIPTION
This PR adds import commands for the Application Load Balancer and DynamoDB terraform locks table to resolve the following errors:

- `Error: ELBv2 Load Balancer (protein-classifier-alb) already exists`
- `Error: creating AWS DynamoDB Table (protein-classifier-terraform-locks): operation error DynamoDB: CreateTable, https response error StatusCode: 400, ResourceInUseException: Table already exists`

The import commands will bring these existing AWS resources under Terraform management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure management by extending automated resource import capabilities to include application load balancer and database lock management, improving infrastructure state tracking and operational consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->