### PR TITLE
Enable DynamoDB table for state locking

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -16,7 +16,7 @@ terraform {
     bucket = "protein-classifier-terraform-state"
     key    = "protein-classifier/terraform.tfstate"
     region = "us-west-2"
-    # dynamodb_table = "protein-classifier-terraform-locks"
+    dynamodb_table = "protein-classifier-terraform-locks"
     encrypt = true
   }
 }


### PR DESCRIPTION
Fixes Terraform state initialization issue by uncommenting the DynamoDB table configuration.

This resolves the checksum mismatch error that was preventing Terraform Apply from running:

```
Error refreshing state: state data in S3 does not have the expected content.
```

The backend.tf file had the `dynamodb_table` line commented out during the bootstrap process, but the workflow was still passing it via backend-config, causing a configuration mismatch. This change completes the bootstrap process by re-enabling the DynamoDB state locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled DynamoDB state locking for Terraform backend configuration to improve consistency in distributed infrastructure deployments and prevent concurrent modification conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->