### PR TITLE
Add KMS key policy dependency to ALB

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -175,7 +175,7 @@ resource "aws_lb" "main" {
     Name = "protein-classifier-alb"
   }
 
-  depends_on = [aws_s3_bucket_policy.alb_logs]
+  depends_on = [aws_s3_bucket_policy.alb_logs, aws_kms_key_policy.alb_logs_s3]
 }
 
 # Target Group for ECS


### PR DESCRIPTION
## Problem

The Terraform Apply workflow is failing because the ALB resource tries to create/modify the load balancer before the KMS key policy for the ALB logs S3 bucket is updated. This creates a dependency ordering issue where:

1. PR #132 fixed the KMS key policy to remove the restrictive encryption context condition
2. However, the ALB resource doesn't explicitly depend on the KMS key policy
3. Terraform may try to create the ALB before updating the KMS policy
4. The ALB creation fails with "Access Denied for bucket" error because the old KMS policy is still in effect

## Solution

Add `aws_kms_key_policy.alb_logs_s3` to the `depends_on` list for the `aws_lb.main` resource. This ensures that Terraform will:

1. First update the KMS key policy with the correct permissions
2. Then create/modify the ALB with access logging enabled

This fixes the dependency ordering and ensures the KMS policy is applied before the ALB tries to verify S3 bucket permissions.

## Testing

After merging this PR, the Terraform Apply workflow should complete successfully without the "Access Denied for bucket" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced load balancer infrastructure configuration with additional dependency declarations to improve deployment stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->