### PR TITLE
Fix ALB S3 logging by adding BucketOwnerPreferred ownership controls

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -11,6 +11,16 @@ resource "aws_s3_bucket" "alb_logs" {
   }
 }
 
+# S3 Bucket Ownership Controls for ALB logs bucket
+# Set to BucketOwnerPreferred to enable ACLs which are required for ALB log delivery to KMS-encrypted buckets
+resource "aws_s3_bucket_ownership_controls" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 # S3 Bucket Versioning for ALB Logs
 resource "aws_s3_bucket_versioning" "alb_logs" {
   bucket = aws_s3_bucket.alb_logs.id
@@ -192,6 +202,7 @@ resource "aws_lb" "main" {
   depends_on = [
     aws_s3_bucket_policy.alb_logs,
     aws_s3_bucket_public_access_block.alb_logs,
+    aws_s3_bucket_ownership_controls.alb_logs,
     aws_s3_bucket_server_side_encryption_configuration.alb_logs,
     aws_kms_key_policy.alb_logs_s3
   ]


### PR DESCRIPTION
## Root Cause
The ALB was unable to write logs to the S3 bucket because the bucket had Object Ownership set to "BucketOwnerEnforced" which disables ACLs. ALB log delivery to KMS-encrypted S3 buckets requires ACLs to be enabled.

## Solution
Added `aws_s3_bucket_ownership_controls` resource with `object_ownership = "BucketOwnerPreferred"` setting, which:
- Enables ACLs on the bucket
- Allows ALB service to properly write encrypted logs
- Maintains secure bucket owner ownership of all objects
- Follows AWS best practices for ALB logging to KMS-encrypted buckets

## Changes
- Added `aws_s3_bucket_ownership_controls.alb_logs` resource
- Added dependency in ALB resource to ensure ownership controls are applied before ALB tries to write logs

This is the industry-standard configuration for ALB logging with server-side KMS encryption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to properly configure S3 bucket ownership for ALB logs, ensuring reliable log delivery to KMS-encrypted storage buckets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->